### PR TITLE
Don't change transform="translate(1,2)" to translate="1,2"

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -66,29 +66,6 @@ const trimElementChilden = children => children.filter(child => (typeof child ==
 
 const usePropValue = 'USE_PROP';
 
-const getTrasnformValueByString = (value) => {
-  const regex = /([^ ]*)\(([^()]*(?=\)))/g; // transform(1, 2) => transform(1, 2
-
-  return value.match(regex).reduce((obj, match) => {
-    const [transformName, transformValue] = match.split('(');
-
-
-    let modifiedTransformValue = transformValue;
-
-    if (transformName === 'translate') {
-      modifiedTransformValue = transformValue.split(' ').join(', ');
-    }
-
-    return Object.assign(
-      {},
-      obj,
-      {
-        [transformName]: modifiedTransformValue,
-      },
-    );
-  }, {});
-};
-
 const obtainComponentAtts = ({ attributes }, enabledAttributes) => {
   const styleAtts = {};
   Array.from(attributes).forEach(({ nodeName, nodeValue }) => {
@@ -106,8 +83,6 @@ const obtainComponentAtts = ({ attributes }, enabledAttributes) => {
       let value;
       if (['fill', 'stroke'].indexOf(nodeName) !== -1 && nodeValue === 'replace') {
         value = usePropValue;
-      } else if (nodeName === 'transform') {
-        value = getTrasnformValueByString(nodeValue);
       } else {
         value = nodeValue;
       }


### PR DESCRIPTION
I was wondering why some of the SVG images do not render correctly in https://github.com/kristerkari/react-native-svg-example.

It turns out that `react-native-svg-loader` changes this:

```svg
<g transform="translate(455.4502,200.8125)">
```

to this:

```jsx
<G translate="455.4502,200.8125">
```

Which does not work with`react-native-svg`.

After I removed the code to change the `transform` property, the SVG images started rendering correctly.

Related issue:
https://github.com/react-native-community/react-native-svg/issues/717#issuecomment-401663071

@unimonkiez 